### PR TITLE
Fix Python 3.9 compatibility for X | None type hints

### DIFF
--- a/enchat_lib/link_sharing.py
+++ b/enchat_lib/link_sharing.py
@@ -1,7 +1,7 @@
 """
 Handles the creation and consumption of temporary, one-time-use links for sharing room credentials.
 """
-
+from __future__ import annotations
 import os
 import base64
 from cryptography.fernet import Fernet

--- a/enchat_lib/session_key.py
+++ b/enchat_lib/session_key.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import time
 import base64


### PR DESCRIPTION
## Summary

- `enchat` failed to start on Python 3.9 with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`
- Root cause: `bytes | None` / `str | None` union syntax in type hints requires Python 3.10+
- Fix: added `from __future__ import annotations` to `session_key.py` and `link_sharing.py`, enabling lazy annotation evaluation (PEP 563) on Python 3.7+

## Affected files

- `enchat_lib/session_key.py`
- `enchat_lib/link_sharing.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)